### PR TITLE
Fix Docusaurus build issue

### DIFF
--- a/docs/meeting-minutes/2020.2.20-general-meeting.md
+++ b/docs/meeting-minutes/2020.2.20-general-meeting.md
@@ -1,5 +1,5 @@
 ---
-id: 2020-02-20-Pure/Alloy-monthly-general-meeting
+id: 2020-02-20-Pure-Alloy-monthly-general-meeting
 title: 2020.2.20 Pure Alloy Monthly General Meeting
 sidebar_label: 2020.2.20 Monthly General Meeting
 ---


### PR DESCRIPTION
`/` chars are not allowed in page ids. Build breaks with:

```
> @ build /Users/m/w/projects/purealloy/website
> docusaurus-build

Error: Document id cannot include "/".
    at Object.processMetadata (/Users/m/w/projects/purealloy/website/node_modules/docusaurus/lib/server/readMetadata.js:150:11)
    at translateDoc (/Users/m/w/projects/purealloy/website/node_modules/docusaurus/lib/write-translations.js:85:28)
    at forEach (/Users/m/w/projects/purealloy/website/node_modules/docusaurus/lib/write-translations.js:105:46)
    at Array.forEach (<anonymous>)
    at execute (/Users/m/w/projects/purealloy/website/node_modules/docusaurus/lib/write-translations.js:105:30)
    at Object.<anonymous> (/Users/m/w/projects/purealloy/website/node_modules/docusaurus/lib/write-translations.js:214:1)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Module._compile (/Users/m/w/projects/purealloy/website/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Object.newLoader (/Users/m/w/projects/purealloy/website/node_modules/pirates/lib/index.js:104:7)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ build: `docusaurus-build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/m/.npm/_logs/2020-02-25T12_30_12_140Z-debug.log
```

It's good practice toi run `npm run build` locally, before making commits, and to check https://github.com/maoo/purealloy/actions when submitting/merging PRs.